### PR TITLE
Strict pangrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ get in touch and I can help you get started.
 
 Some things about the UI that might not be obvious:
 
-A player's score "bubble" is filled with a solid color if they have found a pangram (TODO: *all*
-the pangrams.)
+A player's score "bubble" is filled with a solid color if they have found all the pangrams.
 
 The number in the main, colored score bubble for the player is the score for all of the words
 found by the player so far. A number like "+7" in the grey bubble to the right of it is the number
@@ -60,8 +59,7 @@ is also shown on the right.
 
 The "Group" score bubble is filled if *every* pangram has been found by *someone* in the group.
 That is, on days when more than one pangram is available, the Group score bubble remains
-unfilled as long as there is a pangram that no one has found yet. Note: this is a clue; there
-would otherwise be no way to tell whether another pangram is available.
+unfilled as long as there is a pangram that no one has found yet.
 
 
 ## Backend

--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ Example response body:
         ["glom", ["jeff", "steve"]]
     ],
     "hints": {
-        "maxScore": 150
+        "maxScore": 150,
+        "pangramCount": 1
     },
     "friends": {
-        "steve": { "hasPangram": true, "score": 120 },
-        "jeff": { "hasPangram": false, "score": 6 },
-        "dave": { "hasPangram": false, "score": 0 }
+        "steve": { "hasPangram": true, "score": 120, "hasAllPangrams": false },
+        "jeff": { "hasPangram": false, "score": 6, "hasAllPangrams": false },
+        "dave": { "hasPangram": false, "score": 0, "hasAllPangrams": false }
     },
     "co-op": {
         "hasAllPangrams": true,

--- a/src/Bee.elm
+++ b/src/Bee.elm
@@ -409,7 +409,7 @@ beeView model =
                                 [ -- Note: this is the player's score based a local count of the words they found,
                                   -- not the score under .friends (which should be the same), probably because of
                                   -- guest mode?
-                                  scoreBanner colors data.hints.maxScore (apparentScore user data) localHasPangram
+                                  scoreBanner colors data.hints.maxScore (apparentScore user data) localHasAllPangrams
                                 , whenLatest <| entered colors Edit Submit Shuffle model.input
                                 , whenLatest <|
                                     case model.message of
@@ -484,6 +484,12 @@ beeView model =
                             data.found
                                 |> List.any (isPangram << Tuple.first)
 
+                        localHasAllPangrams =
+                            data.found
+                                |> List.filter (isPangram << Tuple.first)
+                                |> List.length
+                                |> (==) data.hints.pangramCount
+
                         ( user, friends, groupInfo ) =
                             case data.user of
                                 Nothing ->
@@ -498,7 +504,7 @@ beeView model =
                                                     0
                                     in
                                     ( "Guest"
-                                    , Dict.insert "Guest" (UserInfo localScore localHasPangram) data.friends
+                                    , Dict.insert "Guest" (UserInfo localScore localHasPangram localHasAllPangrams) data.friends
                                     , GroupInfo localScore False
                                     )
 

--- a/src/Demo/FrozenFound.elm
+++ b/src/Demo/FrozenFound.elm
@@ -42,12 +42,13 @@ startModel =
                 ]
             , hints =
                 { maxScore = 150
+                , pangramCount = 2
                 }
             , friends =
                 Dict.fromList
-                    [ ( "Steve", { score = 120, hasPangram = True } )
-                    , ( "Jeff", { score = 6, hasPangram = False } )
-                    , ( "Dave", { score = 0, hasPangram = False } )
+                    [ ( "Steve", { score = 120, hasPangram = True, hasAllPangrams = True } )
+                    , ( "Jeff", { score = 6, hasPangram = False, hasAllPangrams = False } )
+                    , ( "Dave", { score = 0, hasPangram = False, hasAllPangrams = False } )
                     ]
             , group = { score = 121, hasAllPangrams = False }
             }

--- a/src/Demo/FrozenPrevious.elm
+++ b/src/Demo/FrozenPrevious.elm
@@ -43,20 +43,21 @@ startModel =
                 ]
             , hints =
                 { maxScore = 150
+                , pangramCount = 1
                 }
             , friends =
                 Dict.fromList
-                    [ ( "steve", { score = 120, hasPangram = True } )
-                    , ( "jeff", { score = 6, hasPangram = False } )
-                    , ( "dave", { score = 0, hasPangram = False } )
+                    [ ( "steve", { score = 120, hasPangram = True, hasAllPangrams = True } )
+                    , ( "jeff", { score = 6, hasPangram = True, hasAllPangrams = False } )
+                    , ( "dave", { score = 0, hasPangram = False, hasAllPangrams = False } )
                     ]
-            , group = { score = 121, hasAllPangrams = False }
+            , group = { score = 121, hasAllPangrams = True }
             }
     , letters = Array.fromList [ 'a', 'g', 'l', 'o', 'm', 'r', 'u' ]
     , input = [ 'l', 'o', 'a', 'm' ]
     , selectedPuzzleId = Just 1234
     , message = None
-    , wordSort = Found
+    , wordSort = Alpha
     , viewport = Size 375 675
     , colorMode = Night
     }

--- a/src/Demo/FrozenToday.elm
+++ b/src/Demo/FrozenToday.elm
@@ -41,12 +41,13 @@ startModel =
                 ]
             , hints =
                 { maxScore = 150
+                , pangramCount = 2
                 }
             , friends =
                 Dict.fromList
-                    [ ( "steve", { score = 120, hasPangram = True } )
-                    , ( "jeff", { score = 6, hasPangram = False } )
-                    , ( "dave", { score = 0, hasPangram = False } )
+                    [ ( "steve", { score = 120, hasPangram = True, hasAllPangrams = True } )
+                    , ( "jeff", { score = 6, hasPangram = False, hasAllPangrams = False } )
+                    , ( "dave", { score = 0, hasPangram = False, hasAllPangrams = False } )
                     ]
             , group = { score = 121, hasAllPangrams = False }
             }

--- a/src/Demo/Thermo.elm
+++ b/src/Demo/Thermo.elm
@@ -62,9 +62,9 @@ view mode =
                 colors
                 "Steve"
                 (Dict.fromList
-                    [ ( "Steve", UserInfo 72 True )
-                    , ( "Dave", UserInfo 0 False )
-                    , ( "Jeff", UserInfo 57 True )
+                    [ ( "Steve", UserInfo 72 True True )
+                    , ( "Dave", UserInfo 0 False False )
+                    , ( "Jeff", UserInfo 57 True False )
                     ]
                 )
                 (Dict.fromList

--- a/src/Puzzle.elm
+++ b/src/Puzzle.elm
@@ -71,12 +71,20 @@ type alias Puzzle =
 -}
 type alias Hints =
     { maxScore : Int
+    , pangramCount : Int
+
+    -- Possible: fourLetterWordCount, totalWordCount
     }
 
 
 type alias UserInfo =
     { score : Int
+
+    -- Has this user found at least one pangram?
     , hasPangram : Bool
+
+    -- Has this user found every pangram?
+    , hasAllPangrams : Bool
     }
 
 
@@ -85,6 +93,8 @@ Called "co-op" in JSON, but how do you spell that in camelCase?
 -}
 type alias GroupInfo =
     { score : Int
+
+    -- Has every pangram been found by at least one member of the group?
     , hasAllPangrams : Bool
     }
 
@@ -208,12 +218,14 @@ webBackend baseUrl =
         decodeHints =
             Decode.succeed Hints
                 |> required "maxScore" int
+                |> required "pangramCount" int
 
         decodeUserInfo : Decoder UserInfo
         decodeUserInfo =
             Decode.succeed UserInfo
                 |> required "score" int
                 |> required "hasPangram" bool
+                |> required "hasAllPangrams" bool
 
         decodeGroupInfo : Decoder GroupInfo
         decodeGroupInfo =

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -658,7 +658,20 @@ wordList colors sortOrder resortMsg minimumWordsPerColumn words allKnown =
             in
             case sortOrder of
                 Found ->
-                    List.reverse
+                    -- Tricky: preserve the order of the words the user has found, but reversed
+                    -- to put the latest first on screen. Follow them with any unfound words
+                    -- (when looking at a previous-day puzzle), sorted alphabetically.
+                    List.sortBy
+                        (\entry ->
+                            ( falseFirst entry.foundByUser
+                            , if entry.foundByUser then
+                                ""
+
+                              else
+                                entry.word
+                            )
+                        )
+                        << List.reverse
 
                 Alpha ->
                     List.sortBy <| \entry -> ( falseFirst entry.foundByUser, falseFirst (isPangram entry.word), entry.word )

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -219,7 +219,7 @@ puzzleFooter colors editor =
 {-| View with the score "thermo" along with the name of the highest level that's been reached.
 -}
 scoreBanner : Colors -> Int -> Int -> Bool -> Element msg
-scoreBanner colors maxScore score hasPangram =
+scoreBanner colors maxScore score hasAllPangrams =
     column
         [ spacing 3
         , centerX
@@ -229,7 +229,7 @@ scoreBanner colors maxScore score hasPangram =
             , centerX
             ]
             (text <| scoreRating maxScore score)
-        , scoreThermo (mainThermoStyle colors) maxScore score hasPangram
+        , scoreThermo (mainThermoStyle colors) maxScore score hasAllPangrams
         ]
 
 
@@ -443,22 +443,22 @@ friendList colors user friends decorations maxScore groupScore groupHasAllPangra
         toEntry : User -> FriendEntry
         toEntry u =
             if u == user then
-                Player user (userHasPangram user)
+                Player user (userHasAllPangrams user)
 
             else
                 case Dict.get u decorations of
                     Just ( color, extraScore ) ->
-                        Friend u color extraScore (userHasPangram u)
+                        Friend u color extraScore (userHasAllPangrams u)
 
                     -- Note: doesn't happen if inputs are correct.
                     Nothing ->
                         Friend u colors.inactiveForeground 0 False
 
-        userHasPangram : User -> Bool
-        userHasPangram u =
+        userHasAllPangrams : User -> Bool
+        userHasAllPangrams u =
             case Dict.get u friends of
                 Just info ->
-                    info.hasPangram
+                    info.hasAllPangrams
 
                 -- Note: doesn't happen if inputs are correct.
                 Nothing ->
@@ -538,12 +538,12 @@ friendList colors user friends decorations maxScore groupScore groupHasAllPangra
                   , view =
                         \( entry, score ) ->
                             case entry of
-                                Player _ hasPangram ->
-                                    scoreThermo (smallThermoStyle colors colors.primaryTint) maxScore score hasPangram
+                                Player _ hasAllPangrams ->
+                                    scoreThermo (smallThermoStyle colors colors.primaryTint) maxScore score hasAllPangrams
 
-                                Friend _ color _ hasPangram ->
+                                Friend _ color _ hasAllPangrams ->
                                     if score > 0 then
-                                        scoreThermo (smallThermoStyle colors color) maxScore score hasPangram
+                                        scoreThermo (smallThermoStyle colors color) maxScore score hasAllPangrams
 
                                     else
                                         none


### PR DESCRIPTION
Make it more obvious how many pangrams are available by not filling in the bubble for each user until they're all found.

This also makes the behavior of "Group" more consistent: it shows the same thing that would be shown for a user that has all the words combined.

Also (hopefully) fixed sorting by "order found" fro previous days' puzzles to hopefully make more sense.

cc @tundragreen