### PR TITLE
Add a language selector, with English, (Mexican) Spanish, and German options

### DIFF
--- a/src/Bee.elm
+++ b/src/Bee.elm
@@ -390,17 +390,14 @@ beeView model =
         strings =
             Language.stringsFor model.language
 
-        modeButton =
-            colorModeButton colors model.colorMode SetColorMode
-
         decorateHeader hdr =
             Element.row
                 [ Element.width Element.fill
                 , Element.spacing 10
                 ]
                 [ hdr
-                , modeButton
-                , languageButton colors model.language SetLanguage
+                , colorModeButton colors strings model.colorMode SetColorMode
+                , languageButton colors strings model.language SetLanguage
                 ]
 
         body =
@@ -418,12 +415,13 @@ beeView model =
                         hdr =
                             puzzleHeader
                                 colors
+                                strings
                                 data.puzzle.displayDate
                                 (Maybe.map ShowPuzzle data.previousPuzzleId)
                                 (Maybe.map ShowPuzzle data.nextPuzzleId)
 
                         ftr =
-                            puzzleFooter colors data.puzzle.editor
+                            puzzleFooter colors strings data.puzzle.editor
 
                         gameView =
                             Element.column
@@ -462,9 +460,9 @@ beeView model =
                                         , Element.spacing 25
                                         , Element.padding 10
                                         ]
-                                        [ controlButton colors "✗" "Delete" Delete (not <| List.isEmpty model.input)
-                                        , controlButton colors "🤷" "Shuffle" Shuffle True
-                                        , controlButton colors "✓" "Submit" Submit (not <| List.isEmpty model.input)
+                                        [ controlButton colors "✗" strings.deleteDescription Delete (not <| List.isEmpty model.input)
+                                        , controlButton colors "🤷" strings.shuffleDescription Shuffle True
+                                        , controlButton colors "✓" strings.submitDescription Submit (not <| List.isEmpty model.input)
                                         ]
                                 ]
 
@@ -550,7 +548,7 @@ beeView model =
                                 JustFound _ ->
                                     Nothing
                     in
-                    mainLayout (loadingHeader msg) Element.none Element.none Element.none Element.none
+                    mainLayout (loadingHeader strings msg) Element.none Element.none Element.none Element.none
     in
     Element.layout
         [ bodyFont
@@ -570,6 +568,10 @@ desiredColumnWidth =
 -}
 inputError : Model -> Maybe String
 inputError model =
+    let
+        strings =
+            stringsFor model.language
+    in
     case model.data of
         Nothing ->
             Nothing
@@ -579,7 +581,7 @@ inputError model =
                 Just ""
 
             else if List.any ((==) (String.fromList model.input) << Tuple.first) data.found then
-                Just "Already found"
+                Just strings.alreadyFoundMessage
 
             else
                 let
@@ -588,27 +590,13 @@ inputError model =
                             List.filter (\c -> c /= data.puzzle.centerLetter && not (List.member c data.puzzle.outerLetters)) model.input
                 in
                 if Set.size wrong > 0 then
-                    let
-                        pluralized =
-                            if Set.size wrong == 1 then
-                                "Wrong letter"
-
-                            else
-                                "Wrong letters"
-
-                        wrongStr =
-                            wrong
-                                |> Set.toList
-                                |> List.intersperse ' '
-                                |> String.fromList
-                    in
-                    Just <| pluralized ++ ": " ++ wrongStr
+                    Just <| strings.wrongLettersMessage wrong
 
                 else if List.length model.input < 4 then
-                    Just "Too short"
+                    Just <| strings.tooShortMessage
 
                 else if List.all ((/=) data.puzzle.centerLetter) model.input then
-                    Just "Missing center letter"
+                    Just <| strings.missingCenterLetterMessage
 
                 else
                     Nothing

--- a/src/Bee.elm
+++ b/src/Bee.elm
@@ -322,10 +322,14 @@ update backend msg model =
                             )
 
                 ReceiveWord (Result.Err err) ->
+                    -- Note: if an error happens here, the word passed local validation,
+                    -- so we assume that it's just not part of the solution. However, if
+                    -- something goes wrong on the server or network it gets trapped here,
+                    -- and a couple of times that's been pretty confusing.
                     ( Debug.log (Debug.toString err)
                         { model
                             | input = []
-                            , message = Warning "Not in word list"
+                            , message = Warning strings.notInWordListMessage
                         }
                     , Cmd.none
                     )

--- a/src/Demo/FrozenFound.elm
+++ b/src/Demo/FrozenFound.elm
@@ -7,9 +7,10 @@ import Array
 import Bee exposing (Message(..), Model)
 import Demo.FrozenMain exposing (Msg, frozenMain)
 import Dict
+import Language exposing (Language(..))
 import Puzzle exposing (..)
-import Views exposing (Size, WordListSortOrder(..))
-import Views.Constants exposing (ColorMode(..))
+import Views exposing (Size)
+import Views.Constants exposing (ColorMode(..), WordListSortOrder(..))
 
 
 main : Program () Model Msg
@@ -59,4 +60,5 @@ startModel =
     , wordSort = Found
     , viewport = Size 375 675
     , colorMode = Night
+    , language = EN
     }

--- a/src/Demo/FrozenLoading.elm
+++ b/src/Demo/FrozenLoading.elm
@@ -7,7 +7,6 @@ import Bee exposing (Model, beeView, startModel)
 import Browser
 import Html exposing (Html)
 import Puzzle exposing (..)
-import Views exposing (WordListSortOrder(..))
 
 
 main : Program () () ()

--- a/src/Demo/FrozenMain.elm
+++ b/src/Demo/FrozenMain.elm
@@ -10,7 +10,7 @@ import Browser.Events
 import Html exposing (Html)
 import Puzzle exposing (..)
 import Task
-import Views exposing (Size, WordListSortOrder(..))
+import Views exposing (Size)
 
 
 frozenMain : Model -> Program () Model Msg

--- a/src/Demo/FrozenPrevious.elm
+++ b/src/Demo/FrozenPrevious.elm
@@ -7,9 +7,10 @@ import Array
 import Bee exposing (Message(..), Model)
 import Demo.FrozenMain exposing (Msg, frozenMain)
 import Dict
+import Language exposing (Language(..))
 import Puzzle exposing (..)
-import Views exposing (Size, WordListSortOrder(..))
-import Views.Constants exposing (ColorMode(..))
+import Views exposing (Size)
+import Views.Constants exposing (ColorMode(..), WordListSortOrder(..))
 
 
 main : Program () Model Msg
@@ -60,4 +61,5 @@ startModel =
     , wordSort = Alpha
     , viewport = Size 375 675
     , colorMode = Night
+    , language = ES
     }

--- a/src/Demo/FrozenToday.elm
+++ b/src/Demo/FrozenToday.elm
@@ -7,9 +7,10 @@ import Array
 import Bee exposing (Message(..), Model)
 import Demo.FrozenMain exposing (Msg, frozenMain)
 import Dict
+import Language exposing (Language(..))
 import Puzzle exposing (..)
-import Views exposing (Size, WordListSortOrder(..))
-import Views.Constants exposing (ColorMode(..))
+import Views exposing (Size)
+import Views.Constants exposing (ColorMode(..), WordListSortOrder(..))
 
 
 main : Program () Model Msg
@@ -58,4 +59,5 @@ startModel =
     , wordSort = Found
     , viewport = Size 375 675
     , colorMode = Night
+    , language = ES
     }

--- a/src/Demo/Thermo.elm
+++ b/src/Demo/Thermo.elm
@@ -10,6 +10,7 @@ import Element.Background as Background
 import Element.Font as Font
 import Element.Input exposing (button)
 import Html exposing (Html)
+import Language exposing (Language(..), stringsFor)
 import Puzzle exposing (UserInfo)
 import Views exposing (friendList, scoreBanner)
 import Views.Constants exposing (..)
@@ -43,6 +44,9 @@ view mode =
     let
         colors =
             themeColors mode
+
+        strings =
+            stringsFor EN
     in
     Element.layout
         [ Background.color colors.background
@@ -52,14 +56,15 @@ view mode =
             [ Element.spacing 10
             , Element.padding 10
             ]
-            [ scoreBanner colors 100 0 False -- Beginner (0)
-            , scoreBanner colors 100 43 False -- Great
-            , scoreBanner colors 100 50 True -- Amazing
-            , scoreBanner colors 100 72 False -- Genius (+2)
-            , scoreBanner colors 100 100 True -- Queen Bee
+            [ scoreBanner colors strings 100 0 False -- Beginner (0)
+            , scoreBanner colors strings 100 43 False -- Great
+            , scoreBanner colors strings 100 50 True -- Amazing
+            , scoreBanner colors strings 100 72 False -- Genius (+2)
+            , scoreBanner colors strings 100 100 True -- Queen Bee
             , Element.el [ Element.padding 20 ] Element.none
             , friendList
                 colors
+                strings
                 "Steve"
                 (Dict.fromList
                     [ ( "Steve", UserInfo 72 True True )

--- a/src/Demo/Words.elm
+++ b/src/Demo/Words.elm
@@ -8,7 +8,8 @@ import Element exposing (column, el, none, padding, spacing)
 import Element.Background as Background
 import Element.Font as Font
 import Html exposing (Html)
-import Views exposing (WordEntry, WordListSortOrder(..), wordList)
+import Language exposing (Language(..), stringsFor)
+import Views exposing (WordEntry, wordList)
 import Views.Constants exposing (..)
 
 
@@ -47,6 +48,7 @@ view model =
             , padding 10
             ]
             [ wordList colors
+                strings
                 Alpha
                 Resort
                 3
@@ -54,6 +56,7 @@ view model =
                 ]
                 False
             , wordList colors
+                strings
                 Alpha
                 Resort
                 3
@@ -62,6 +65,7 @@ view model =
                 ]
                 True
             , wordList colors
+                strings
                 Alpha
                 Resort
                 3
@@ -71,6 +75,7 @@ view model =
                 ]
                 False
             , wordList colors
+                strings
                 Alpha
                 Resort
                 3
@@ -82,6 +87,7 @@ view model =
                 ]
                 False
             , wordList colors
+                strings
                 Alpha
                 Resort
                 3
@@ -96,6 +102,7 @@ view model =
                 False
             , el [ padding 10 ] none
             , wordList colors
+                strings
                 model.dynamicSortOrder
                 Resort
                 3
@@ -129,6 +136,10 @@ view model =
 
 colors =
     themeColors Night
+
+
+strings =
+    stringsFor EN
 
 
 friend1 =

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -1,0 +1,185 @@
+module Language exposing
+    ( Language(..)
+    , Strings
+    , rotate
+    , stringsFor
+    )
+
+import Views.Constants exposing (ScoreLevel(..), WordListSortOrder(..))
+
+
+type Language
+    = EN
+    | ES
+
+
+rotate : Language -> Language
+rotate language =
+    case language of
+        EN ->
+            ES
+
+        ES ->
+            EN
+
+
+type alias Strings =
+    { scoreLabel : ScoreLevel -> String
+    , foundLabel : Int -> Maybe Int -> String
+    , sortLabel : WordListSortOrder -> String
+    , sortDescription : String
+    , friendsLabel : String
+    , guestLabel : String
+    }
+
+
+enStrings : Strings
+enStrings =
+    { scoreLabel =
+        \level ->
+            case level of
+                ScoreLevel0 ->
+                    "Beginner"
+
+                ScoreLevel1 ->
+                    "Good Start"
+
+                ScoreLevel2 ->
+                    "Moving Up"
+
+                ScoreLevel3 ->
+                    "Good"
+
+                ScoreLevel4 ->
+                    "Solid"
+
+                ScoreLevel5 ->
+                    "Nice"
+
+                ScoreLevel6 ->
+                    "Great"
+
+                ScoreLevel7 ->
+                    "Amazing"
+
+                ScoreLevel8 ->
+                    "Genius"
+
+                ScoreLevel9 ->
+                    "Queen Bee"
+    , foundLabel =
+        \found totalMay ->
+            let
+                numMsg =
+                    case ( found, totalMay ) of
+                        ( x, Just y ) ->
+                            String.fromInt x ++ " of " ++ String.fromInt y
+
+                        ( x, Nothing ) ->
+                            String.fromInt x
+
+                wordsStr =
+                    case Maybe.withDefault found totalMay of
+                        1 ->
+                            "word"
+
+                        _ ->
+                            "words"
+            in
+            "Found " ++ numMsg ++ " " ++ wordsStr
+    , sortLabel =
+        \order ->
+            case order of
+                Found ->
+                    "f↑"
+
+                Alpha ->
+                    "a↑"
+
+                Length ->
+                    "l↑"
+    , sortDescription = "Sort Order"
+    , friendsLabel = "Friends"
+    , guestLabel = "Guest"
+    }
+
+
+esStrings : Strings
+esStrings =
+    { scoreLabel =
+        \level ->
+            case level of
+                ScoreLevel0 ->
+                    "Principiante"
+
+                ScoreLevel1 ->
+                    "Buen Comienzo"
+
+                ScoreLevel2 ->
+                    "Mejorando"
+
+                ScoreLevel3 ->
+                    "Bien"
+
+                ScoreLevel4 ->
+                    "Fuerte"
+
+                ScoreLevel5 ->
+                    "Lindo"
+
+                ScoreLevel6 ->
+                    "Excelente"
+
+                ScoreLevel7 ->
+                    "Increíble"
+
+                ScoreLevel8 ->
+                    "Genio"
+
+                ScoreLevel9 ->
+                    "Abeja Reina"
+    , foundLabel =
+        \found totalMay ->
+            let
+                numMsg =
+                    case ( found, totalMay ) of
+                        ( x, Just y ) ->
+                            String.fromInt x ++ " de " ++ String.fromInt y
+
+                        ( x, Nothing ) ->
+                            String.fromInt x
+
+                wordsStr =
+                    case Maybe.withDefault found totalMay of
+                        1 ->
+                            "palabra"
+
+                        _ ->
+                            "palabras"
+            in
+            "Encontraste " ++ numMsg ++ " " ++ wordsStr
+    , sortLabel =
+        \order ->
+            case order of
+                Found ->
+                    "e↑"
+
+                Alpha ->
+                    "a↑"
+
+                Length ->
+                    "l↑"
+    , sortDescription = "Orden de Clasificación"
+    , friendsLabel = "Amigos"
+    , guestLabel = "Visitante"
+    }
+
+
+stringsFor : Language -> Strings
+stringsFor language =
+    case language of
+        EN ->
+            enStrings
+
+        ES ->
+            esStrings

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -5,6 +5,7 @@ module Language exposing
     , stringsFor
     )
 
+import Array
 import Views.Constants exposing (ScoreLevel(..), WordListSortOrder(..))
 
 
@@ -36,37 +37,18 @@ type alias Strings =
 enStrings : Strings
 enStrings =
     { scoreLabel =
-        \level ->
-            case level of
-                ScoreLevel0 ->
-                    "Beginner"
-
-                ScoreLevel1 ->
-                    "Good Start"
-
-                ScoreLevel2 ->
-                    "Moving Up"
-
-                ScoreLevel3 ->
-                    "Good"
-
-                ScoreLevel4 ->
-                    "Solid"
-
-                ScoreLevel5 ->
-                    "Nice"
-
-                ScoreLevel6 ->
-                    "Great"
-
-                ScoreLevel7 ->
-                    "Amazing"
-
-                ScoreLevel8 ->
-                    "Genius"
-
-                ScoreLevel9 ->
-                    "Queen Bee"
+        scoreLabels
+            "Beginner"
+            [ "Good Start"
+            , "Moving Up"
+            , "Good"
+            , "Solid"
+            , "Nice"
+            , "Great"
+            , "Amazing"
+            , "Genius"
+            , "Queen Bee"
+            ]
     , foundLabel =
         \found totalMay ->
             let
@@ -107,37 +89,18 @@ enStrings =
 esStrings : Strings
 esStrings =
     { scoreLabel =
-        \level ->
-            case level of
-                ScoreLevel0 ->
-                    "Principiante"
-
-                ScoreLevel1 ->
-                    "Buen Comienzo"
-
-                ScoreLevel2 ->
-                    "Mejorando"
-
-                ScoreLevel3 ->
-                    "Bien"
-
-                ScoreLevel4 ->
-                    "Fuerte"
-
-                ScoreLevel5 ->
-                    "Lindo"
-
-                ScoreLevel6 ->
-                    "Excelente"
-
-                ScoreLevel7 ->
-                    "Increíble"
-
-                ScoreLevel8 ->
-                    "Genio"
-
-                ScoreLevel9 ->
-                    "Abeja Reina"
+        scoreLabels
+            "Principiante"
+            [ "Buen Comienzo"
+            , "Mejorando"
+            , "Bien"
+            , "Fuerte"
+            , "Lindo"
+            , "Excelente"
+            , "Increíble"
+            , "Genio"
+            , "Abeja Reina"
+            ]
     , foundLabel =
         \found totalMay ->
             let
@@ -183,3 +146,27 @@ stringsFor language =
 
         ES ->
             esStrings
+
+
+
+-- Helpers:
+
+
+scoreLabels : String -> List String -> ScoreLevel -> String
+scoreLabels beginnerStr strs =
+    let
+        pairs =
+            List.map2 Tuple.pair strs [ ScoreLevel1, ScoreLevel2, ScoreLevel3, ScoreLevel4, ScoreLevel5, ScoreLevel6, ScoreLevel7, ScoreLevel8, ScoreLevel9 ]
+    in
+    \level ->
+        pairs
+            |> List.filterMap
+                (\( s, l ) ->
+                    if l == level then
+                        Just s
+
+                    else
+                        Nothing
+                )
+            |> List.head
+            |> Maybe.withDefault beginnerStr

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -11,6 +11,7 @@ import Views.Constants exposing (ScoreLevel(..), WordListSortOrder(..))
 
 type Language
     = EN
+    | DE
     | ES
 
 
@@ -18,6 +19,9 @@ rotate : Language -> Language
 rotate language =
     case language of
         EN ->
+            DE
+
+        DE ->
             ES
 
         ES ->
@@ -137,6 +141,73 @@ enStrings =
     }
 
 
+deStrings : Strings
+deStrings =
+    { icon = "🇩🇪"
+    , titleLabel = "Spelling Bee"
+    , loadingLabel = "lädt…"
+    , editorLabel = \ed -> "Puzzle von " ++ ed
+    , attributionLabel = "für die "
+    , nytLabel = "New York Times"
+    , sourceLabel = "Quelle und Dokumente "
+    , hereLabel = "hier"
+
+    -- Puzzle controls:
+    , scoreLabel =
+        scoreLabels
+            "Anfänger"
+            [ "Guter Anfang"
+            , "Aufsteigend"
+            , "Gut"
+            , "Solid"
+            , "Nett"
+            , "Großartig"
+            , "Erstaunlich"
+            , "Genie"
+            , "Bienenkönigin"
+            ]
+    , foundLabel =
+        foundLabels
+            "1 Word gefunden"
+            (\m -> m ++ " Wörter gefunden")
+            (\m n -> m ++ " von " ++ n ++ " Wörter gefunden")
+    , sortLabel =
+        \order ->
+            case order of
+                Found ->
+                    "g↑"
+
+                Alpha ->
+                    "a↑"
+
+                Length ->
+                    "l↑"
+    , friendsLabel = "Freunde"
+    , groupLabel = "Gruppe"
+    , guestLabel = "Gast"
+
+    -- Error messages:
+    , alreadyFoundMessage = "schon gefunden"
+    , wrongLettersMessage =
+        wrongLettersMessage
+            (\ls -> "falscher Buchstabe: " ++ ls)
+            (\ls -> "falsche Buchstaben: " ++ ls)
+    , tooShortMessage = "zu kurz"
+    , missingCenterLetterMessage = "fehlender Mittelbuchstabe "
+    , notInWordListMessage = "nicht in der Wortliste"
+
+    -- Accessibility:
+    , previousPuzzleDescription = "<<Previous Puzzle>>"
+    , nextPuzzleDescription = "Nächste Puzzle"
+    , colorModeDescription = "Tag un Nacht"
+    , languageDescription = "Sprache"
+    , sortDescription = "<<Sort Order>>"
+    , deleteDescription = "<<Delete>>"
+    , shuffleDescription = "<<Shuffle>>"
+    , submitDescription = "<<Submit>>"
+    }
+
+
 esStrings : Strings
 esStrings =
     { icon = "🇲🇽"
@@ -209,6 +280,9 @@ stringsFor language =
     case language of
         EN ->
             enStrings
+
+        DE ->
+            deStrings
 
         ES ->
             esStrings

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -34,7 +34,8 @@ with the following exceptions:
 -}
 type alias Strings =
     { -- Header stuff:
-      titleLabel : String
+      icon : String
+    , titleLabel : String
     , loadingLabel : String
     , editorLabel : String -> String
     , attributionLabel : String
@@ -71,7 +72,8 @@ type alias Strings =
 
 enStrings : Strings
 enStrings =
-    { titleLabel = "Spelling Bee"
+    { icon = "🇺🇸"
+    , titleLabel = "Spelling Bee"
     , loadingLabel = "loading…"
     , editorLabel = \ed -> "Puzzle by " ++ ed
     , attributionLabel = "for the "
@@ -137,7 +139,8 @@ enStrings =
 
 esStrings : Strings
 esStrings =
-    { titleLabel = "<<Spelling Bee>>"
+    { icon = "🇲🇽"
+    , titleLabel = "<<Spelling Bee>>"
     , loadingLabel = "<<loading…>>"
     , editorLabel = \ed -> "<<Puzzle by>> " ++ ed
     , attributionLabel = "<<for the>> "

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -5,7 +5,6 @@ module Language exposing
     , stringsFor
     )
 
-import Array
 import Views.Constants exposing (ScoreLevel(..), WordListSortOrder(..))
 
 
@@ -50,25 +49,10 @@ enStrings =
             , "Queen Bee"
             ]
     , foundLabel =
-        \found totalMay ->
-            let
-                numMsg =
-                    case ( found, totalMay ) of
-                        ( x, Just y ) ->
-                            String.fromInt x ++ " of " ++ String.fromInt y
-
-                        ( x, Nothing ) ->
-                            String.fromInt x
-
-                wordsStr =
-                    case Maybe.withDefault found totalMay of
-                        1 ->
-                            "word"
-
-                        _ ->
-                            "words"
-            in
-            "Found " ++ numMsg ++ " " ++ wordsStr
+        foundLabels
+            "Found 1 word"
+            (\m -> "Found " ++ m ++ " words")
+            (\m n -> "Found " ++ m ++ " of " ++ n ++ " words")
     , sortLabel =
         \order ->
             case order of
@@ -102,25 +86,10 @@ esStrings =
             , "Abeja Reina"
             ]
     , foundLabel =
-        \found totalMay ->
-            let
-                numMsg =
-                    case ( found, totalMay ) of
-                        ( x, Just y ) ->
-                            String.fromInt x ++ " de " ++ String.fromInt y
-
-                        ( x, Nothing ) ->
-                            String.fromInt x
-
-                wordsStr =
-                    case Maybe.withDefault found totalMay of
-                        1 ->
-                            "palabra"
-
-                        _ ->
-                            "palabras"
-            in
-            "Encontraste " ++ numMsg ++ " " ++ wordsStr
+        foundLabels
+            "Encontraste 1 palabra"
+            (\m -> "Encontraste " ++ m ++ " palabras")
+            (\m n -> "Encontraste " ++ m ++ " de " ++ n ++ " palabras")
     , sortLabel =
         \order ->
             case order of
@@ -170,3 +139,28 @@ scoreLabels beginnerStr strs =
                 )
             |> List.head
             |> Maybe.withDefault beginnerStr
+
+
+{-| Cases:
+
+  - Found 1 word
+  - Found n words
+  - Found n of m words
+
+-}
+foundLabels :
+    String
+    -> (String -> String)
+    -> (String -> String -> String)
+    -> (Int -> Maybe Int -> String)
+foundLabels oneWord words ofTotal =
+    \found totalMay ->
+        case ( found, totalMay ) of
+            ( 1, Nothing ) ->
+                oneWord
+
+            ( _, Nothing ) ->
+                words (String.fromInt found)
+
+            ( _, Just total ) ->
+                ofTotal (String.fromInt found) (String.fromInt total)

--- a/src/Language.elm
+++ b/src/Language.elm
@@ -5,6 +5,7 @@ module Language exposing
     , stringsFor
     )
 
+import Set exposing (Set)
 import Views.Constants exposing (ScoreLevel(..), WordListSortOrder(..))
 
 
@@ -23,19 +24,63 @@ rotate language =
             EN
 
 
+{-| A record containing all explicit Strings which the user can encounter while playing the game,
+with the following exceptions:
+
+  - symbols and emoji, which are "universal" by design
+  - error messages that arise from programming errors or unexpected backend problems
+  - strings that are embedded in the puzzle from the source (e.g. the puzzle's date)
+
+-}
 type alias Strings =
-    { scoreLabel : ScoreLevel -> String
+    { -- Header stuff:
+      titleLabel : String
+    , loadingLabel : String
+    , editorLabel : String -> String
+    , attributionLabel : String
+    , nytLabel : String
+    , sourceLabel : String
+    , hereLabel : String
+
+    -- Puzzle controls:
+    , scoreLabel : ScoreLevel -> String
     , foundLabel : Int -> Maybe Int -> String
     , sortLabel : WordListSortOrder -> String
-    , sortDescription : String
     , friendsLabel : String
+    , groupLabel : String
     , guestLabel : String
+
+    -- Error messages:
+    , alreadyFoundMessage : String
+    , wrongLettersMessage : Set Char -> String
+    , tooShortMessage : String
+    , missingCenterLetterMessage : String
+    , notInWordListMessage : String
+
+    -- Accessibility labels:
+    , previousPuzzleDescription : String
+    , nextPuzzleDescription : String
+    , colorModeDescription : String
+    , languageDescription : String
+    , sortDescription : String
+    , deleteDescription : String
+    , shuffleDescription : String
+    , submitDescription : String
     }
 
 
 enStrings : Strings
 enStrings =
-    { scoreLabel =
+    { titleLabel = "Spelling Bee"
+    , loadingLabel = "loading…"
+    , editorLabel = \ed -> "Puzzle by " ++ ed
+    , attributionLabel = "for the "
+    , nytLabel = "New York Times"
+    , sourceLabel = "Source and docs "
+    , hereLabel = "here"
+
+    -- Puzzle controls:
+    , scoreLabel =
         scoreLabels
             "Beginner"
             [ "Good Start"
@@ -64,15 +109,44 @@ enStrings =
 
                 Length ->
                     "l↑"
-    , sortDescription = "Sort Order"
     , friendsLabel = "Friends"
+    , groupLabel = "Group"
     , guestLabel = "Guest"
+
+    -- Error messages:
+    , alreadyFoundMessage = "Already Found"
+    , wrongLettersMessage =
+        wrongLettersMessage
+            (\ls -> "Wrong letter: " ++ ls)
+            (\ls -> "Wrong letters: " ++ ls)
+    , tooShortMessage = "Too short"
+    , missingCenterLetterMessage = "Missing center letter"
+    , notInWordListMessage = "Not in word list"
+
+    -- Accessibility:
+    , previousPuzzleDescription = "Previous Puzzle"
+    , nextPuzzleDescription = "Next Puzzle"
+    , colorModeDescription = "Color Mode"
+    , languageDescription = "Language"
+    , sortDescription = "Sort Order"
+    , deleteDescription = "Delete"
+    , shuffleDescription = "Shuffle"
+    , submitDescription = "Submit"
     }
 
 
 esStrings : Strings
 esStrings =
-    { scoreLabel =
+    { titleLabel = "<<Spelling Bee>>"
+    , loadingLabel = "<<loading…>>"
+    , editorLabel = \ed -> "<<Puzzle by>> " ++ ed
+    , attributionLabel = "<<for the>> "
+    , nytLabel = "New York Times"
+    , sourceLabel = "<<Source and docs>> "
+    , hereLabel = "aqui"
+
+    -- Puzzle controls:
+    , scoreLabel =
         scoreLabels
             "Principiante"
             [ "Buen Comienzo"
@@ -101,9 +175,29 @@ esStrings =
 
                 Length ->
                     "l↑"
-    , sortDescription = "Orden de Clasificación"
     , friendsLabel = "Amigos"
+    , groupLabel = "<<Group>>"
     , guestLabel = "Visitante"
+
+    -- Error messages:
+    , alreadyFoundMessage = "<<Already Found>>"
+    , wrongLettersMessage =
+        wrongLettersMessage
+            (\ls -> "<<Wrong letter>>: " ++ ls)
+            (\ls -> "<<Wrong letters>>: " ++ ls)
+    , tooShortMessage = "<<Too short>>"
+    , missingCenterLetterMessage = "<<Missing center letter>>"
+    , notInWordListMessage = "<<Not in word list>>"
+
+    -- Accessibility:
+    , previousPuzzleDescription = "<<Previous Puzzle>>"
+    , nextPuzzleDescription = "<<Next Puzzle>>"
+    , colorModeDescription = "<<Color Mode>>"
+    , languageDescription = "<<Language>>"
+    , sortDescription = "Orden de Clasificación"
+    , deleteDescription = "<<Delete>>"
+    , shuffleDescription = "<<Shuffle>>"
+    , submitDescription = "<<Submit>>"
     }
 
 
@@ -164,3 +258,22 @@ foundLabels oneWord words ofTotal =
 
             ( _, Just total ) ->
                 ofTotal (String.fromInt found) (String.fromInt total)
+
+
+wrongLettersMessage :
+    (String -> String)
+    -> (String -> String)
+    -> (Set Char -> String)
+wrongLettersMessage oneLetter letters wrong =
+    let
+        wrongStr =
+            wrong
+                |> Set.toList
+                |> List.intersperse ' '
+                |> String.fromList
+    in
+    if Set.size wrong == 1 then
+        oneLetter wrongStr
+
+    else
+        letters wrongStr

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -145,13 +145,7 @@ colorModeButton colors strings colorMode handle =
 languageButton : Colors -> Strings -> Language -> (Language -> msg) -> Element msg
 languageButton colors strings language handle =
     lightweightButton colors
-        (case language of
-            EN ->
-                "🇺🇸"
-
-            ES ->
-                "🇲🇽"
-        )
+        strings.icon
         strings.languageDescription
         (Just <| handle <| Language.rotate language)
 

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -129,8 +129,8 @@ mainLayout header game words friends footer desiredColumnWidth actualViewport =
             ]
 
 
-colorModeButton : Colors -> ColorMode -> (ColorMode -> msg) -> Element msg
-colorModeButton colors colorMode handle =
+colorModeButton : Colors -> Strings -> ColorMode -> (ColorMode -> msg) -> Element msg
+colorModeButton colors strings colorMode handle =
     lightweightButton colors
         (if colorMode == Day then
             "☼"
@@ -138,12 +138,12 @@ colorModeButton colors colorMode handle =
          else
             "☾"
         )
-        "Color Mode"
+        strings.colorModeDescription
         (Just <| handle <| Views.Constants.rotate colorMode)
 
 
-languageButton : Colors -> Language -> (Language -> msg) -> Element msg
-languageButton colors language handle =
+languageButton : Colors -> Strings -> Language -> (Language -> msg) -> Element msg
+languageButton colors strings language handle =
     lightweightButton colors
         (case language of
             EN ->
@@ -152,12 +152,12 @@ languageButton colors language handle =
             ES ->
                 "🇲🇽"
         )
-        "Language"
+        strings.languageDescription
         (Just <| handle <| Language.rotate language)
 
 
-puzzleHeader : Colors -> String -> Maybe msg -> Maybe msg -> Element msg
-puzzleHeader colors date previousMsg nextMsg =
+puzzleHeader : Colors -> Strings -> String -> Maybe msg -> Maybe msg -> Element msg
+puzzleHeader colors strings date previousMsg nextMsg =
     column
         [ centerX
         ]
@@ -165,15 +165,15 @@ puzzleHeader colors date previousMsg nextMsg =
             [ spacing 10
             , Font.size 16
             ]
-            [ lightweightButton colors "←" "Previous Puzzle" previousMsg
-            , lightweightButton colors "→" "Next Puzzle" nextMsg
+            [ lightweightButton colors "←" strings.previousPuzzleDescription previousMsg
+            , lightweightButton colors "→" strings.nextPuzzleDescription nextMsg
             , el [] (text date)
             ]
         ]
 
 
-loadingHeader : Maybe String -> Element msg
-loadingHeader msg =
+loadingHeader : Strings -> Maybe String -> Element msg
+loadingHeader strings msg =
     column
         [ headerFont
         , centerX
@@ -183,18 +183,18 @@ loadingHeader msg =
             [ Font.bold
             , Font.size 24
             ]
-            (text "Spelling Bee")
+            (text <| strings.titleLabel)
         , el
             [ Font.light
             , Font.size 16
             , Font.italic
             ]
-            (text <| Maybe.withDefault "loading…" msg)
+            (text <| Maybe.withDefault strings.loadingLabel msg)
         ]
 
 
-puzzleFooter : Colors -> String -> Element msg
-puzzleFooter colors editor =
+puzzleFooter : Colors -> Strings -> String -> Element msg
+puzzleFooter colors strings editor =
     column
         [ centerX
         , spacing 5
@@ -204,16 +204,18 @@ puzzleFooter colors editor =
             [ Font.light
             , Font.size 16
             ]
-            (text <| "Puzzle by " ++ editor)
+            (text <| strings.editorLabel editor)
         , row
             [ Font.light
             , Font.size 16
             ]
-            [ text "for the "
+            [ text <| strings.attributionLabel
             , link
                 []
                 { url = "https://www.nytimes.com/puzzles/spelling-bee"
-                , label = el [ Font.italic, mouseOver [ Font.color colors.activeHilite ] ] (text "New York Times")
+                , label =
+                    el [ Font.italic, mouseOver [ Font.color colors.activeHilite ] ]
+                        (text <| strings.nytLabel)
                 }
             ]
         , el [] (text " ") -- space
@@ -221,11 +223,13 @@ puzzleFooter colors editor =
             [ Font.light
             , Font.size 16
             ]
-            [ text "Source and docs "
+            [ text <| strings.sourceLabel
             , link
                 []
                 { url = "https://github.com/mossprescott/spelling-bee"
-                , label = el [ Font.italic, mouseOver [ Font.color colors.activeHilite ] ] (text "here")
+                , label =
+                    el [ Font.italic, mouseOver [ Font.color colors.activeHilite ] ]
+                        (text <| strings.hereLabel)
                 }
             ]
         ]
@@ -544,7 +548,7 @@ friendList colors strings user friends decorations maxScore groupScore groupHasA
                                                 n
 
                                             Group _ ->
-                                                "Group"
+                                                strings.groupLabel
                                 in
                                 el (playerFontStyles entry) <| text name
                   }
@@ -703,21 +707,7 @@ wordList colors strings sortOrder resortMsg minimumWordsPerColumn words allKnown
 
                     else
                         Nothing
-
-                -- numMsg =
-                --     case ( found, totalMay ) of
-                --         ( x, Just y ) ->
-                --             String.fromInt x ++ " of " ++ String.fromInt y
-                --         ( x, Nothing ) ->
-                --             String.fromInt x
-                -- wordsStr =
-                --     case Maybe.withDefault found totalMay of
-                --         1 ->
-                --             "word"
-                --         _ ->
-                --             "words"
             in
-            -- "Found " ++ numMsg ++ " " ++ wordsStr
             strings.foundLabel found totalMay
     in
     column

--- a/src/Views/Constants.elm
+++ b/src/Views/Constants.elm
@@ -1,8 +1,11 @@
 module Views.Constants exposing
     ( ColorMode(..)
     , Colors
+    , ScoreLevel(..)
+    , WordListSortOrder(..)
     , bodyFont
     , headerFont
+    , nextSortOrder
     , rotate
     , themeColors
     )
@@ -180,3 +183,35 @@ bodyFont =
         , Font.typeface "Helvetica Neue"
         , Font.sansSerif
         ]
+
+
+type WordListSortOrder
+    = Found
+    | Alpha
+    | Length
+
+
+nextSortOrder : WordListSortOrder -> WordListSortOrder
+nextSortOrder order =
+    case order of
+        Found ->
+            Alpha
+
+        Alpha ->
+            Length
+
+        Length ->
+            Found
+
+
+type ScoreLevel
+    = ScoreLevel0
+    | ScoreLevel1
+    | ScoreLevel2
+    | ScoreLevel3
+    | ScoreLevel4
+    | ScoreLevel5
+    | ScoreLevel6
+    | ScoreLevel7
+    | ScoreLevel8
+    | ScoreLevel9

--- a/src/Views/Thermo.elm
+++ b/src/Views/Thermo.elm
@@ -5,6 +5,7 @@ import Element exposing (..)
 import Element.Background as Background
 import Element.Border as Border
 import Element.Font as Font
+import Views.Constants exposing (ScoreLevel(..))
 
 
 type alias ThermoStyle =
@@ -47,25 +48,25 @@ scoreThermo style maxScore score hasBonus =
 {-| Score level thresholds, painstakingly reverse-engineered. Note: Queen Bee doesn't appear in
 thermos (until you actually achieve it), to encourage a sense of accomplishment at Genius level.
 -}
-thresholds : Array ( String, Float )
+thresholds : Array ( ScoreLevel, Float )
 thresholds =
     Array.fromList
-        [ ( "Beginner", 0.0 )
-        , ( "Good Start", 0.02 )
-        , ( "Moving Up", 0.05 )
-        , ( "Good", 0.08 )
-        , ( "Solid", 0.15 )
-        , ( "Nice", 0.25 )
-        , ( "Great", 0.4 )
-        , ( "Amazing", 0.5 )
-        , ( "Genius", 0.7 )
-        , ( "Queen Bee", 1.0 )
+        [ ( ScoreLevel0, 0.0 )
+        , ( ScoreLevel1, 0.02 )
+        , ( ScoreLevel2, 0.05 )
+        , ( ScoreLevel3, 0.08 )
+        , ( ScoreLevel4, 0.15 )
+        , ( ScoreLevel5, 0.25 )
+        , ( ScoreLevel6, 0.4 )
+        , ( ScoreLevel7, 0.5 )
+        , ( ScoreLevel8, 0.7 )
+        , ( ScoreLevel9, 1.0 )
         ]
 
 
-scoreRating : Int -> Int -> String
+scoreRating : Int -> Int -> ScoreLevel
 scoreRating maxScore score =
-    Maybe.withDefault "" <|
+    Maybe.withDefault ScoreLevel0 <|
         List.head <|
             List.reverse <|
                 List.filterMap


### PR DESCRIPTION
Mostly because it amuses me to that a significant subset of the users are living in places where English isn't the first language.

The main controls are all translated for Spanish, albeit by me. Footer text, messages, and accessibility descriptions still need attention.

Not yet deployed, but I wanted to merge this and move on to other things, so this will get deployed sooner or later. If it looks too ugly in the meantime I might take away the button to switch.
